### PR TITLE
Add all color syntax available in Notepad++ 7.7.1

### DIFF
--- a/src/xml/nord.xml
+++ b/src/xml/nord.xml
@@ -4,1383 +4,1383 @@ Copyright (c) 2016-present Arctic Ice Studio <development@arcticicestudio.com>
 Copyright (c) 2016-present Sven Greb <code@svengreb.de>
 
 Project:    Nord Notepad++
-Version:    0.2.0
+Version:    0.1.0
 Repository: https://github.com/arcticicestudio/nord-notepadplusplus
 License:    MIT
 References
 https://developer.apple.com/xcode
 -->
 <NotepadPlus>
-  <GlobalStyles>
-    <!-- Attention : Don't modify the name of styleID="0" -->
-    <WidgetStyle name="Global override" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontSize="12" fontStyle="0" />
-    <WidgetStyle name="Default Style" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontName="Source Code Pro" fontSize="12" fontStyle="0" />
-    <WidgetStyle name="Active tab focused indicator" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Active tab text" styleID="0" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
-    <WidgetStyle name="Active tab unfocused indicator" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Bad brace colour" styleID="35" bgColor="BF616A" fgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Brace highlight style" styleID="34" bgColor="88C0D0" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Caret colour" styleID="2069" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Current line background colour" styleID="0" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Edge colour" styleID="0" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
-    <WidgetStyle name="Find Mark Style" styleID="31" bgColor="81A1C1" fgColor="81A1C1" fontStyle="0" />
-    <WidgetStyle name="Fold" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    <WidgetStyle name="Fold active" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Fold margin" styleID="0" bgColor="2E3440" fgColor="434C5E" fontStyle="0" />
-    <WidgetStyle name="Inactive tabs" styleID="0" bgColor="D8DEE9" fgColor="434C5E" fontStyle="0" />
-    <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="81A1C1" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Indent guideline style" styleID="37" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
-    <WidgetStyle name="Line number margin" styleID="33" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    <WidgetStyle name="Mark Style 1" styleID="25" bgColor="B48EAD" fgColor="B48EAD" fontStyle="0" />
-    <WidgetStyle name="Mark Style 2" styleID="24" bgColor="A3BE8C" fgColor="A3BE8C" fontStyle="0" />
-    <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EBCB8B" fgColor="EBCB8B" fontStyle="0" />
-    <WidgetStyle name="Mark Style 4" styleID="22" bgColor="D08770" fgColor="D08770" fontStyle="0" />
-    <WidgetStyle name="Mark Style 5" styleID="21" bgColor="BF616A" fgColor="BF616A" fontStyle="0" />
-    <WidgetStyle name="Selected text colour" styleID="0" bgColor="434C5E" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="88C0D0" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Tags attribute" styleID="26" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-    <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-    <WidgetStyle name="URL hovered" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="White space symbol" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-  </GlobalStyles>
-  <LexerStyles>
-    <LexerType name="actionscript" desc="ActionScript" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="FUNCTION" styleID="20" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="ada" desc="ADA" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="10" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DELIMITER" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="IDENTIFIER" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="ILLEGAL" styleID="11" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="1" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="LABEL" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="asm" desc="Assembly" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT BLOCK" styleID="11" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="CPU INSTRUCTION" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="DIRECTIVE" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="DIRECTIVE OPERAND" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type3" />
-      <WordsStyle name="EXT INSTRUCTION" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
-      <WordsStyle name="IDENTIFIER" styleID="5" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="MATH INSTRUCTION" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="REGISTER" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="asn1" desc="ASN.1" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTES" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DESCRIPTORS" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="DOUBLE QUOTED STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="IDENTIFIERS" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
-      <WordsStyle name="KEYWORDS" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="NON OID NUMBERS" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="NUMERIC OID DEFINITION" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="OPERATORS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="TYPES" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type2" />
-    </LexerType>
-    <LexerType name="asp" desc="asp" ext="asp">
-      <WordsStyle name="DEFAULT" styleID="81" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ASPSYBOL" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
-      <WordsStyle name="COMMENTLINE" styleID="82" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="86" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="83" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="SCRIPTTYPE" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="85" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="WORD" styleID="84" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-    </LexerType>
-    <LexerType name="autoit" desc="autoIt" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMOBJ" styleID="14" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="EXPAND" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" keywordClass="type5" />
-      <WordsStyle name="FUNCTION" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="MACRO" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type3" />
-      <WordsStyle name="SENT" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="SPECIAL" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type4" />
-      <WordsStyle name="STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="2" />
-    </LexerType>
-    <LexerType name="avs" desc="AviSynth" ext="">
-      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CLIP PROPERTIES" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" keywordClass="type3" />
-      <WordsStyle name="COMMENT: /* */" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT: [* *]" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOUBLE QUOTED STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="FILTER" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="FUNCTION" styleID="12" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="IDENTIFIERS" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="LINE COMMENT: #" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATORS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PLUGIN" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="STRING WITH THREE DOUBLE QUOTES" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="USER DEFINED" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type4" />
-      <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="baanc" desc="BaanC" ext="">
-      <WordsStyle name="DEFAULT" styleID="8" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="3" />
-      <WordsStyle name="FUNCTIONS" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="KEYWORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING EOL NC" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="3" />
-    </LexerType>
-    <LexerType name="bash" desc="bash" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BACKTICKS" styleID="11" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="6" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="HERE DELIM" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="HERE Q" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PARAM" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="SCALAR" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="batch" desc="Batch" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMAND" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="HIDE SYBOL" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="KEYWORDS" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="LABEL" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="blitzbasic" desc="BlitzBasic" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="c" desc="C" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="caml" desc="Caml" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="CHARACTER" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="14" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="13" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="LINENUM" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
-      <WordsStyle name="NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="11" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TAGNAME" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="TYPE" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
-    </LexerType>
-    <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMAND" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="FOREACHDEF" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
-      <WordsStyle name="IFDEF" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
-      <WordsStyle name="MACRODEF" styleID="12" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="PARAMETER" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="STRING D" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING L" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="2" />
-      <WordsStyle name="STRING R" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="4" />
-      <WordsStyle name="STRING VARIABLE" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
-      <WordsStyle name="USER DEFINED" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="VARIABLE" styleID="7" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="WHILEDEF" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
-    </LexerType>
-    <LexerType name="cobol" desc="COBOL" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="DECLARATION" styleID="5" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="KEYWORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="coffeescript" desc="CoffeeScript" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT BLOCK" styleID="22" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREDEFINED CONSTANT" styleID="19" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type2" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="VERBOSE REGEX" styleID="23" bgColor="2E3440" fgColor="B48EAD" fontStyle="3" />
-      <WordsStyle name="VERBOSE REGEX COMMENT" styleID="24" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-    </LexerType>
-    <LexerType name="cpp" desc="C++" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="cs" desc="C#" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="csound" desc="Csound" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="A-RATE VARIABLE" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT BLOCK" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="GLOBAL VARIABLE" styleID="14" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="HEADER STATEMENT" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="IDENTIFIER" styleID="5" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTR" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="I-RATE VARIABLE" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="K-RATE VARIABLE" styleID="12" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPCODE" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="OPERATOR" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PARAMETER" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
-      <WordsStyle name="USER KEYWORDS" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-    </LexerType>
-    <LexerType name="css" desc="CSS" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CLASS" styleID="2" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DIRECTIVE" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="ID" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="IMPORTANT" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PSEUDOCLASS" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="VALUE" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    </LexerType>
-    <LexerType name="d" desc="D" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="17" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT NESTED" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="14" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="KEWORD1" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="KEWORD2" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="KEWORD3" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="KEWORD4" styleID="20" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
-      <WordsStyle name="KEWORD5" styleID="21" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type4" />
-      <WordsStyle name="KEWORD6" styleID="22" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type5" />
-      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING B" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING R" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="diff" desc="DIFF" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ADDED" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="COMMAND" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DELETED" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="HEADER" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="POSITION" styleID="4" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-    </LexerType>
-    <LexerType name="erlang" desc="Erlang" ext="">
-      <WordsStyle name="DEFAULT COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DEFAULT STYLE" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ATOM" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="ATOM QUOTED" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="BUILT-IN FUNCTIONS" styleID="22" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="CHARACTER" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="DOCUMENTATION HELPER IN COMMENT" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type3" />
-      <WordsStyle name="DOCUMENTATION MACRO IN COMMENT" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="3" keywordClass="type4" />
-      <WordsStyle name="FUNCTION NAME" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="FUNCTION COMMENT" styleID="14" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="MACRO" styleID="10" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="MACRO QUOTED" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="MODULE ATTRIBUTES" styleID="24" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="MODULE COMMENT" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="MODULE NAME" styleID="23" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="NODE NAME" styleID="13" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="NODE NAME QUOTED" styleID="21" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATORS" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="RECORD" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
-      <WordsStyle name="RECORD QUOTED" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-      <WordsStyle name="RESERVED WORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="UNKNOWN: ERROR" styleID="31" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="2" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="escript" desc="ESCRIPT" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BRACES" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOC COMMENT" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="DOUBLE QUOTED STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="IDENTIFIERS" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="KEYWORDS2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="KEYWORDS3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATORS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-    </LexerType>
-    <LexerType name="forth" desc="Forth" ext="">
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="CONTROL" styleID="4" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="DEFWORDS" styleID="6" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="DOUBLE QUOTED STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" keywordClass="type4" />
-      <WordsStyle name="IDENTIFIER" styleID="3" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
-      <WordsStyle name="KEYWORDS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="LOCALE" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="ML COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="PREWORD1" styleID="7" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type2" />
-      <WordsStyle name="PREWORD2" styleID="8" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type3" />
-      <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="fortran" desc="Fortran (free form)" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="CONTINUATION" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="FUNCTION1" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="FUNCTION2" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="LABEL" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="OPERATOR2" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING2" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-    </LexerType>
-    <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="CONTINUATION" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="FUNCTION1" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="FUNCTION2" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="LABEL" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="OPERATOR2" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING2" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-    </LexerType>
-    <LexerType name="freebasic" desc="FreeBasic" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0">endfunction endif</WordsStyle>
-      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="gui4cli" desc="GUI4CLI" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTE" styleID="16" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="COMMAND" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type3" />
-      <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="CONTROL" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="EVENT" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="GLOBAL" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="haskell" desc="Haskell" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CAPITAL" styleID="8" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CLASS" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK" styleID="14" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK2" styleID="15" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK3" styleID="16" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="13" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DATA" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="IMPORT" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="INSTANCE" styleID="12" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="MODULE" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="html" desc="HTML" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="CDATA" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOUBLESTRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="ENTITY" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="SGMLDEFAULT" styleID="21" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="SINGLESTRING" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="TAGEND" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="TAGUNKNOWN" styleID="2" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="VALUE" styleID="19" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    </LexerType>
-    <LexerType name="ihex" desc="Intel HEX" ext="">
-      <!-- RECCOUNT 8 N/A -->
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="DATA_EMPTY" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
-      <WordsStyle name="DATA_UNKNOWN" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="EXTENDEDADDRESS" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
-      <WordsStyle name="NOADDRESS" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-    </LexerType>
-    <LexerType name="ini" desc="ini file" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ASSIGNMENT" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DEFVAL" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="SECTION" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    </LexerType>
-    <LexerType name="inno" desc="InnoSetup" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT PASCAL" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="KEYWORD PASCAL" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type3" />
-      <WordsStyle name="KEYWORD USER" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
-      <WordsStyle name="PARAMETER" styleID="3" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR INLINE" styleID="6" bgColor="2E3440" fgColor="D08770" fontStyle="1" />
-      <WordsStyle name="SECTION" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="STRING DOUBLE" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING SINGLE" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-    </LexerType>
-    <LexerType name="java" desc="Java" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-      <WordsStyle name="DEFAULT" styleID="41" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="42" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTDOC" styleID="44" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="43" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOUBLESTRING" styleID="48" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="47" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="45" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="52" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="SINGLESTRING" styleID="49" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="SYMBOLS" styleID="50" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="WORD" styleID="46" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-    </LexerType>
-    <LexerType name="javascript.js" desc="JavaScript" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="FFFFFF" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0">True False</WordsStyle>
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRINGRAW" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="WINDOW INSTRUCTION" styleID="19" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
-    </LexerType>
-    <LexerType name="json" desc="JSON" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BOOLEAN NULL" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING DOUBLE QUOTE" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING SINGLE QUOTE" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-    </LexerType>
-    <LexerType name="kix" desc="KiXtart" ext="">
-      <WordsStyle name="DEFAULT" styleID="31" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="FUNCTION" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="MACRO" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0">if else for while</WordsStyle>
-      <WordsStyle name="OPERATOR" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0">bool long int char</WordsStyle>
-      <WordsStyle name="STRING" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING2" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="VAR" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="latex" desc="LaTeX" ext="">
-      <WordsStyle name="COMMAND" styleID="1" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="COMMAND OPTIONAL ARGUMENT" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT BLOCK" styleID="7" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="MATH BLOCK" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="MATH INLINE" styleID="3" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="SHORT COMMAND" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="SPECIAL CHAR" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="SYNTAX ERROR" styleID="12" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="TAG CLOSING" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="TAG OPENING" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="VERBATIM SEGMENT" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="lisp" desc="LISP" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="FUNCTION WORD" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="FUNCTION WORD2" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="SPECIAL" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="SYMBOL" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
-    </LexerType>
-    <LexerType name="lua" desc="Lua" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="FUNC1" styleID="13" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="FUNC2" styleID="14" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="FUNC3" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="LABEL" styleID="20" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="LITERALSTRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="makefile" desc="Makefile" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="3" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="IDEOL" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="2" />
-      <WordsStyle name="OPERATOR" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="PREPROCESSOR" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="TARGET" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="matlab" desc="Matlab" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMAND" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="mmixal" desc="MMIXAL" ext="">
-      <WordsStyle name="CHAR" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT OTHERWISE" styleID="17" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="DIVISION BETWEEN LABEL AND OPCODE" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="DIVISION BETWEEN OPCODE AND OPERANDS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="DIVISION OF OPERANDS" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="DIVSION OF LEADING WHITESPACE IN LINE" styleID="0" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="HEXADECIMAL NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="LABEL" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPCODE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="REFERENCE (TO A LABEL)" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="REGISTER" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="STRING" styleID="12" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="SYMBOL" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="UNKNOWN OPCODE" styleID="6" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="VALID OPCODE" styleID="5" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre1" />
-    </LexerType>
-    <LexerType name="nfo" desc="Dos Style" ext="">
-      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="nimrod" desc="Nimrod" ext="">
-      <WordsStyle name="CLASS NAME DEFINITION" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT-BLOCKS" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DECORATORS" styleID="15" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="FUNCTION OR METHOD NAME DEFINITION" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
-      <WordsStyle name="HIGHLIGHTED IDENTIFIERS" styleID="14" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="IDENTIFIERS" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATORS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="SINGLE QUOTED STRING" styleID="4" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TRIPLE DOUBLE QUOTES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TRIPLE QUOTES" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="nncrontab" desc="extended crontab" ext="">
-      <WordsStyle name="ASTERISK" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOUBLE QUOTED STRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="ENVIRONMENT VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="10" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2">if else for while</WordsStyle>
-      <WordsStyle name="MODIFICATORS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="2" keywordClass="type1">bool long int char</WordsStyle>
-      <WordsStyle name="NUMBER" styleID="7" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="SECTION KEYWORDS" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="TASK START/END" styleID="2" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="nsis" desc="NSIS" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="18" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="FUNCTION" styleID="5" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
-      <WordsStyle name="IF DEFINE" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0">if else for while</WordsStyle>
-      <WordsStyle name="LABEL" styleID="7" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1">bool long int char</WordsStyle>
-      <WordsStyle name="MACRO" styleID="12" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="PAGE EX" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="SECTION" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
-      <WordsStyle name="SECTION GROUP" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
-      <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING LEFT QUOTE" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING RIGHT QUOTE" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING VAR" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="SUBSECTION" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
-      <WordsStyle name="USER DEFINED" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="4" keywordClass="type2" />
-      <WordsStyle name="VARIABLE" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="objc" desc="Objective-C" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0">if else for while</WordsStyle>
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0">bool long int char</WordsStyle>
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="DIRECTIVE" styleID="19" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="QUALIFIER" styleID="20" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="oscript" desc="OScript" ext="">
-      <WordsStyle name="#IFDEF DOC AND #ENDIF" styleID="3" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="DEFAULT TEXT STYLE" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CONSTANT LITERAL" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORDS" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="KEYWORDS" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
-      <WordsStyle name="LABEL TO JUMP TO WITH THE GOTO STATEMENT" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="LANGUAGE NATIVE KEYWORD OR RESERVED WORD" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="MULTI-LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OBJECT METHOD" styleID="18" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="OBJECT PROPERTY" styleID="17" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="OPERATOR; EITHER SYMBOLIC OR LITERAL" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="PREPROCESSOR DIRECTIVE" styleID="4" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="SERVER-GLOBAL VARIABLE (PREFIXED BY $)" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="SINGLE-LINE COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="STATIC BUILT-IN OBJECT" styleID="16" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" keywordClass="type4" />
-      <WordsStyle name="STRING DOUBLE QUOTES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING SINGLE QUOTES" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-    </LexerType>
-    <LexerType name="pascal" desc="Pascal" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ASM" styleID="14" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
-      <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="HEX NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="7" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR2" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="perl" desc="Perl" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ARRAY" styleID="13" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="BACKTICKS" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DATASECTION" styleID="21" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="HASH" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="LONGQUOTE" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="POD" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PUNCTUATION" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="REGSUBST" styleID="18" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="SCALAR" styleID="12" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="SYMBOL TABLE" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
-    </LexerType>
-    <LexerType name="php" desc="php" ext="">
-      <WordsStyle name="DEFAULT" styleID="118" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="124" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="125" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="122" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="127" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="QUESTION MARK" styleID="18" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="SIMPLESTRING" styleID="120" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="119" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING VARIABLE" styleID="126" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="123" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="WORD" styleID="121" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-    </LexerType>
-    <LexerType name="postscript" desc="Postscript" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BAD STRING CHAR" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="BASE85 STRING" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DSC COMMENT" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="DSC VALUE" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="HEX STRING" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="IMMEVAL" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="LITERAL" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="NAME" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="PAREN ARRAY" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="PAREN DICT" styleID="10" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="PAREN PROC" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="TEXT" styleID="12" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="powershell" desc="PowerShell" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ALIAS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="CHARACTER" styleID="3" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CMDLET" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type4" />
-      <WordsStyle name="COMMENT STREAM" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="HERE CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="HERE STRING" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
-    </LexerType>
-    <LexerType name="props" desc="Properties file" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ASSIGNMENT" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DEFVAL" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="SECTION" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    </LexerType>
-    <LexerType name="purebasic" desc="PureBasic" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="CONSTANT" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="python" desc="Python" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CLASSNAME" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DECORATOR" styleID="15" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
-      <WordsStyle name="DEFNAME" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="F CHARACTER" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="F STRING" styleID="16" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="F TRIPLE" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="F TRIPLEDOUBLE" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORDS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TRIPLE" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TRIPLEDOUBLE" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="r" desc="R" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BASE WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INFIX" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="KEYWORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING2" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="rc" desc="RC" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="rebol" desc="REBOL" ext="">
-      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ANY OTHER TEXT" styleID="0" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-      <WordsStyle name="BINARY ( 16#{1A803F59} )" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="BLOCK COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="CHARACTERS" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="DATE { 17-FEB-2004 1/3/99 }" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="EMAIL { JOE@MAIL.DOM }" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="FILE { %/C/WINNT/SOME.DLL }" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="IDENTIFIERS" styleID="20" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="ISSUE { #123-CD-456 }" styleID="13" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="KEYWORD (ALL)" styleID="21" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="KEYWORD (DATATYPES)" styleID="23" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="KEYWORD (TEST FUNCTIONS)" styleID="22" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="KEYWORD 4" styleID="24" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="KEYWORD 5" styleID="25" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
-      <WordsStyle name="KEYWORD 6" styleID="26" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type4" />
-      <WordsStyle name="KEYWORD 7" styleID="27" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type5" />
-      <WordsStyle name="LINE COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="MONEY" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATORS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="PAIR ( 800X600 )" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREFACE" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-      <WordsStyle name="STRING WITH BRACES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING WITH QUOTES" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TAG { &lt;TITLE HEIGHT=100&gt; }" styleID="14" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="TIME { 12:30 11:22:59 01:59:59.123 }" styleID="19" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="TUPLE ( 127.0.0.1 )" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="URL { FTP://THERE.DOM }" styleID="17" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    </LexerType>
-    <LexerType name="registry" desc="registry" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="DEFAULT STYLE" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ADDED KEY" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="ESCAPED CHARACTERS IN STRINGS" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
-      <WordsStyle name="GUID IN KEY PATH" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="GUID IN STRING" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="HEX DIGIT" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATORS" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="PARAMETER" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="REMOVED KEY" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="VALUE NAME" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="VALUE TYPE" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-    </LexerType>
-    <LexerType name="ruby" desc="Ruby" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BACKTICKS" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CLASS NAME" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="CLASS VAR" styleID="17" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DATA SECTION" styleID="19" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="DEF NAME" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="GLOBAL" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTANCE VAR" styleID="16" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="MODULE NAME" styleID="15" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="POD" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING Q" styleID="24" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="SYMBOL" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="rust" desc="Rust" ext="">
-      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BLOCK COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="BLOCK DOC COMMENT" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="BYTE CHARACTER" styleID="23" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="BYTE STRING" styleID="21" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="17" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORDS 1" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="KEYWORDS 2" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="KEYWORDS 3" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="KEYWORDS 4" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type2" />
-      <WordsStyle name="KEYWORDS 5" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type3" />
-      <WordsStyle name="KEYWORDS 6" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
-      <WordsStyle name="KEYWORDS 7" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type5" />
-      <WordsStyle name="LEXICAL ERROR" styleID="20" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="LIFETIME" styleID="18" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="LINE DOC COMMENT" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="MACRO" styleID="19" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="RAW BYTE STRING" styleID="22" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="RAW STRING" styleID="14" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="REGULAR STRING" styleID="13" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
-    </LexerType>
-    <LexerType name="scheme" desc="Scheme" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="FUNCTION WORD" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="FUNCTION WORD2" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="SPECIAL" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="SYMBOL" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
-    </LexerType>
-    <LexerType name="searchResult" desc="Search result" ext="">
-      <WordsStyle name="Current line background colour" styleID="6" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="File Header" styleID="2" bgColor="3B4252" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="Hit Word" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="Line Number" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="Search Header" styleID="1" bgColor="3B4252" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="Selected Line" styleID="5" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="smalltalk" desc="Smalltalk" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ASSIGN" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="BINARY" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="BOOL" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="GLOBAL" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="KWS END" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="NIL" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="RETURN" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="SELF" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="SPECIAL" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="SPECIAL SELECTOR" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="1" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="SUPER" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="SYMBOL" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
-    </LexerType>
-    <LexerType name="spice" desc="spice" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="8" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="IDENTIFIERS" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="KEYWORD2" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="KEYWORD3" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATORS (DELIMITERS)" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
-      <WordsStyle name="VALUE" styleID="7" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-    </LexerType>
-    <LexerType name="sql" desc="SQL" ext="">
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="Q OPERATOR" styleID="24" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING2" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="srec" desc="S-Record" ext="">
-      <!-- EXTENDEDADDRESS 11 N/A -->
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="DATA_EMPTY" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
-      <WordsStyle name="DATA_UNKNOWN" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
-      <WordsStyle name="NOADDRESS" styleID="6" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="RECCOUNT" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-    </LexerType>
-    <LexerType name="swift" desc="Swift" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-    </LexerType>
-    <LexerType name="tcl" desc="TCL" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BLOCK COMMENT" styleID="18" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT BOX" styleID="17" bgColor="2E3440" fgColor="616E88" fontStyle="1" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="EXPAND" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="IN QUOTE" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="MODIFIER" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="SUB BRACE" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="SUBSTITUTION" styleID="8" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="TYPE WORD" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="WORD IN QUOTE" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-    </LexerType>
-    <LexerType name="tehex" desc="Tektronix extended HEX" ext="">
-      <!-- DATA_EMPTY 15 N/A -->
-      <!-- DATA_UNKNOWN 14 N/A -->
-      <!-- EXTENDEDADDRESS 11 N/A -->
-      <!-- NOADDRESS 6 N/A -->
-      <!-- RECCOUNT 8 N/A -->
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
-      <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
-      <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-    </LexerType>
-    <LexerType name="tex" desc="TeX" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMAND" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="GROUP" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
-      <WordsStyle name="SPECIAL" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
-      <WordsStyle name="SYMBOL" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="TEXT" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-    </LexerType>
-    <LexerType name="txt2tags" desc="txt2tags" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="BLOCKQUOTE" styleID="15" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="CODE" styleID="19" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="CODE2" styleID="20" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="CODEBLOCK" styleID="21" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="22" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="EM1 (ITALIC)" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
-      <WordsStyle name="EM2 (UNDERLINE)" styleID="5" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="H1" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
-      <WordsStyle name="H2" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
-      <WordsStyle name="H3" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
-      <WordsStyle name="H4" styleID="9" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
-      <WordsStyle name="H5" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
-      <WordsStyle name="H6" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
-      <WordsStyle name="HRULE" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="LINK" styleID="18" bgColor="2E3440" fgColor="88C0D0" fontStyle="2" />
-      <WordsStyle name="LIST" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="LIST" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="OPTION" styleID="23" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="POSTPROC" styleID="25" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="PRECHAR (NOT USED)" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
-      <WordsStyle name="PREPROC" styleID="24" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="SPECIAL" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRIKEOUT" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="STRONG" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
-      <WordsStyle name="STRONG 2 (NOT USED)" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-    </LexerType>
-    <LexerType name="vb" desc="VB / VBS" ext="">
-      <WordsStyle name="DEFAULT" styleID="7" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DATE" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-    </LexerType>
-    <LexerType name="verilog" desc="Verilog" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE BANG" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="TAGNAME" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="USER" styleID="19" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="vhdl" desc="VHDL" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTE" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="type1" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT LIne" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STD FUNCTION" styleID="11" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type2" />
-      <WordsStyle name="STD OPERATOR" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
-      <WordsStyle name="STD PACKAGE" styleID="12" bgColor="2E3440" fgColor="BF616A" fontStyle="0" keywordClass="type3" />
-      <WordsStyle name="STD TYPE" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type4" />
-      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="USER DEFINE" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type5" />
-    </LexerType>
-    <LexerType name="visualprolog" desc="Visual Prolog" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ANONYMOUS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="CHARACTER ESCAPE ERROR" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="CHARACTER TOO MANY" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT BLOCK" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="COMMENT KEY" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type2" />
-      <WordsStyle name="COMMENT KEY ERROR" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="5" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DIRECTIVE" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="IDENTIFIER" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
-      <WordsStyle name="MAJOR" styleID="1" bgColor="2E3440" fgColor="D08770" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="MINOR" styleID="2" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="NUMBER" styleID="11" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="16" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="STRING EOL OPEN" styleID="19" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING ESCAPE" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="STRING ESCAPE ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="STRING VERBATIM" styleID="20" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="STRING VERBATIM EOL" styleID="22" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="STRING VERBATIM SPECIAL" styleID="21" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    </LexerType>
-    <LexerType name="xml" desc="XML" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="CDATA" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOUBLESTRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
-      <WordsStyle name="ENTITY" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="SGMLDEFAULT" styleID="21" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="SINGLESTRING" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
-      <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="TAGEND" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
-      <WordsStyle name="TAGUNKNOWN" styleID="2" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="XMLEND" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="XMLSTART" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-    </LexerType>
-    <LexerType name="yaml" desc="YAML" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
-      <WordsStyle name="DOCUMENT" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="8" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
-      <WordsStyle name="REFERENCE" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
-      <WordsStyle name="TEXT" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
-    </LexerType>
-  </LexerStyles>
+    <GlobalStyles>
+        <!-- Attention : Don't modify the name of styleID="0" -->
+        <WidgetStyle name="Global override" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontSize="12" fontStyle="0" />
+        <WidgetStyle name="Default Style" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontName="Source Code Pro" fontSize="12" fontStyle="0" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        <WidgetStyle name="Active tab text" styleID="0" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        <WidgetStyle name="Bad brace colour" styleID="35" bgColor="BF616A" fgColor="2E3440" fontStyle="0" />
+        <WidgetStyle name="Brace highlight style" styleID="34" bgColor="88C0D0" fgColor="D8DEE9" fontStyle="0" />
+        <WidgetStyle name="Caret colour" styleID="2069" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="434C5E" fgColor="D8DEE9" fontStyle="0" />
+        <WidgetStyle name="Edge colour" styleID="0" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="81A1C1" fgColor="81A1C1" fontStyle="0" />
+        <WidgetStyle name="Fold" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        <WidgetStyle name="Fold active" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        <WidgetStyle name="Fold margin" styleID="0" bgColor="2E3440" fgColor="2E3440" fontStyle="0" />
+        <WidgetStyle name="Inactive tabs" styleID="0" bgColor="D8DEE9" fgColor="434C5E" fontStyle="0" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="81A1C1" fgColor="D8DEE9" fontStyle="0" />
+        <WidgetStyle name="Indent guideline style" styleID="37" bgColor="3B4252" fgColor="3B4252" fontStyle="0" />
+        <WidgetStyle name="Line number margin" styleID="33" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="B48EAD" fgColor="B48EAD" fontStyle="0" />
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="A3BE8C" fgColor="A3BE8C" fontStyle="0" />
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EBCB8B" fgColor="EBCB8B" fontStyle="0" />
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="D08770" fgColor="D08770" fontStyle="0" />
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="BF616A" fgColor="BF616A" fontStyle="0" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="88C0D0" fgColor="D8DEE9" fontStyle="0" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+        <WidgetStyle name="URL hovered" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        <WidgetStyle name="White space symbol" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    </GlobalStyles>
+    <LexerStyles>
+        <LexerType name="actionscript" desc="ActionScript" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="FUNCTION" styleID="20" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="ada" desc="ADA" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="10" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DELIMITER" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="ILLEGAL" styleID="11" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="asm" desc="Assembly" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type3" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
+            <WordsStyle name="IDENTIFIER" styleID="5" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="REGISTER" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="asn1" desc="ASN.1" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ATTRIBUTES" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DESCRIPTORS" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="IDENTIFIERS" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+            <WordsStyle name="KEYWORDS" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
+            <WordsStyle name="NON OID NUMBERS" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="NUMERIC OID DEFINITION" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="OPERATORS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="TYPES" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type2" />
+        </LexerType>
+        <LexerType name="asp" desc="asp" ext="asp">
+            <WordsStyle name="DEFAULT" styleID="81" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ASPSYBOL" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+            <WordsStyle name="COMMENTLINE" styleID="82" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="86" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="83" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="85" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="WORD" styleID="84" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+        </LexerType>
+        <LexerType name="autoit" desc="autoIt" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMOBJ" styleID="14" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="EXPAND" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" keywordClass="type5" />
+            <WordsStyle name="FUNCTION" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="MACRO" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type3" />
+            <WordsStyle name="SENT" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="SPECIAL" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type4" />
+            <WordsStyle name="STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="2" />
+        </LexerType>
+        <LexerType name="avs" desc="AviSynth" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CLIP PROPERTIES" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" keywordClass="type3" />
+            <WordsStyle name="COMMENT: /* */" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT: [* *]" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="FILTER" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION" styleID="12" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="IDENTIFIERS" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="LINE COMMENT: #" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATORS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PLUGIN" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="STRING WITH THREE DOUBLE QUOTES" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="USER DEFINED" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type4" />
+            <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="baanc" desc="BaanC" ext="">
+            <WordsStyle name="DEFAULT" styleID="8" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="3" />
+            <WordsStyle name="FUNCTIONS" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="KEYWORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING EOL NC" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="3" />
+        </LexerType>
+        <LexerType name="bash" desc="bash" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BACKTICKS" styleID="11" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="6" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="HERE DELIM" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="HERE Q" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PARAM" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="SCALAR" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="batch" desc="Batch" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMAND" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="HIDE SYBOL" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="KEYWORDS" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="LABEL" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="VARIABLE" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="blitzbasic" desc="BlitzBasic" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="c" desc="C" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="caml" desc="Caml" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="CHARACTER" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="14" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="13" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="LINENUM" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+            <WordsStyle name="NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="11" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TAGNAME" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="TYPE" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+        </LexerType>
+        <LexerType name="cmake" desc="CMakeFile" ext="cmake">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMAND" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="FOREACHDEF" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+            <WordsStyle name="IFDEF" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+            <WordsStyle name="MACRODEF" styleID="12" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="PARAMETER" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="STRING D" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING L" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="2" />
+            <WordsStyle name="STRING R" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="4" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+            <WordsStyle name="USER DEFINED" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="VARIABLE" styleID="7" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="WHILEDEF" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+        </LexerType>
+        <LexerType name="cobol" desc="COBOL" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="DECLARATION" styleID="5" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="coffeescript" desc="CoffeeScript" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT BLOCK" styleID="22" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREDEFINED CONSTANT" styleID="19" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="VERBOSE REGEX" styleID="23" bgColor="2E3440" fgColor="B48EAD" fontStyle="3" />
+            <WordsStyle name="VERBOSE REGEX COMMENT" styleID="24" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+        </LexerType>
+        <LexerType name="cpp" desc="C++" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="cs" desc="C#" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="csound" desc="Csound" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="A-RATE VARIABLE" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT BLOCK" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="GLOBAL VARIABLE" styleID="14" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="HEADER STATEMENT" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="IDENTIFIER" styleID="5" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTR" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="I-RATE VARIABLE" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="K-RATE VARIABLE" styleID="12" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPCODE" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="OPERATOR" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PARAMETER" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+            <WordsStyle name="USER KEYWORDS" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+        </LexerType>
+        <LexerType name="css" desc="CSS" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CLASS" styleID="2" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DIRECTIVE" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="ID" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="IMPORTANT" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="VALUE" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        </LexerType>
+        <LexerType name="d" desc="D" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="17" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT NESTED" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="14" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="KEWORD1" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="KEWORD2" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="KEWORD3" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="KEWORD4" styleID="20" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
+            <WordsStyle name="KEWORD5" styleID="21" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type4" />
+            <WordsStyle name="KEWORD6" styleID="22" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type5" />
+            <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING B" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING R" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="diff" desc="DIFF" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ADDED" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="COMMAND" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DELETED" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="HEADER" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="POSITION" styleID="4" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+        </LexerType>
+        <LexerType name="erlang" desc="Erlang" ext="">
+            <WordsStyle name="DEFAULT COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DEFAULT STYLE" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ATOM" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="ATOM QUOTED" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="BUILT-IN FUNCTIONS" styleID="22" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="CHARACTER" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="DOCUMENTATION HELPER IN COMMENT" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type3" />
+            <WordsStyle name="DOCUMENTATION MACRO IN COMMENT" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="3" keywordClass="type4" />
+            <WordsStyle name="FUNCTION NAME" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="FUNCTION COMMENT" styleID="14" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="MACRO" styleID="10" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="MACRO QUOTED" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="MODULE ATTRIBUTES" styleID="24" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="MODULE COMMENT" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="MODULE NAME" styleID="23" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="NODE NAME" styleID="13" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="NODE NAME QUOTED" styleID="21" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATORS" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="RECORD" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+            <WordsStyle name="RECORD QUOTED" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+            <WordsStyle name="RESERVED WORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="UNKNOWN: ERROR" styleID="31" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="VARIABLE" styleID="2" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="escript" desc="ESCRIPT" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BRACES" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOC COMMENT" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="IDENTIFIERS" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="KEYWORDS2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="KEYWORDS3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATORS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+        </LexerType>
+        <LexerType name="forth" desc="Forth" ext="">
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="CONTROL" styleID="4" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="DEFWORDS" styleID="6" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" keywordClass="type4" />
+            <WordsStyle name="IDENTIFIER" styleID="3" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+            <WordsStyle name="KEYWORDS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="LOCALE" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="ML COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="PREWORD1" styleID="7" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type2" />
+            <WordsStyle name="PREWORD2" styleID="8" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type3" />
+            <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="fortran" desc="Fortran (free form)" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="CONTINUATION" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="FUNCTION1" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="OPERATOR2" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING2" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+        </LexerType>
+        <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="CONTINUATION" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="FUNCTION1" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="OPERATOR2" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING2" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+        </LexerType>
+        <LexerType name="freebasic" desc="FreeBasic" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0">endfunction endif</WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="gui4cli" desc="GUI4CLI" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ATTRIBUTE" styleID="16" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="COMMAND" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type3" />
+            <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="CONTROL" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="EVENT" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="GLOBAL" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="haskell" desc="Haskell" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CAPITAL" styleID="8" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CLASS" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="13" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DATA" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="IMPORT" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="INSTANCE" styleID="12" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="MODULE" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="html" desc="HTML" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="CDATA" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="ENTITY" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="SINGLESTRING" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="TAGEND" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="VALUE" styleID="19" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        </LexerType>
+        <LexerType name="ihex" desc="Intel HEX" ext="">
+            <!-- RECCOUNT 8 N/A -->
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="DATA_EMPTY" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+            <WordsStyle name="DATA_UNKNOWN" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="EXTENDEDADDRESS" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+            <WordsStyle name="NOADDRESS" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+        </LexerType>
+        <LexerType name="ini" desc="ini file" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DEFVAL" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="SECTION" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        </LexerType>
+        <LexerType name="inno" desc="InnoSetup" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
+            <WordsStyle name="PARAMETER" styleID="3" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" bgColor="2E3440" fgColor="D08770" fontStyle="1" />
+            <WordsStyle name="SECTION" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING SINGLE" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+        </LexerType>
+        <LexerType name="java" desc="Java" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
+            <WordsStyle name="DEFAULT" styleID="41" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="42" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTDOC" styleID="44" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="43" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="47" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="45" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="52" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="SINGLESTRING" styleID="49" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="SYMBOLS" styleID="50" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="WORD" styleID="46" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+        </LexerType>
+        <LexerType name="javascript.js" desc="JavaScript" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="FFFFFF" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0">True False</WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRINGRAW" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="WINDOW INSTRUCTION" styleID="19" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+        </LexerType>
+        <LexerType name="json" desc="JSON" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BOOLEAN NULL" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING SINGLE QUOTE" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+        </LexerType>
+        <LexerType name="kix" desc="KiXtart" ext="">
+            <WordsStyle name="DEFAULT" styleID="31" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="FUNCTION" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0">if else for while</WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0">bool long int char</WordsStyle>
+            <WordsStyle name="STRING" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING2" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="VAR" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="latex" desc="LaTeX" ext="">
+            <WordsStyle name="COMMAND" styleID="1" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="COMMAND OPTIONAL ARGUMENT" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT BLOCK" styleID="7" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="MATH BLOCK" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="MATH INLINE" styleID="3" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="SHORT COMMAND" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="SPECIAL CHAR" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="SYNTAX ERROR" styleID="12" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="TAG CLOSING" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="TAG OPENING" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="VERBATIM SEGMENT" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="lisp" desc="LISP" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD2" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="SPECIAL" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="SYMBOL" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+        </LexerType>
+        <LexerType name="lua" desc="Lua" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="FUNC1" styleID="13" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="FUNC2" styleID="14" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="FUNC3" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="LABEL" styleID="20" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="LITERALSTRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="makefile" desc="Makefile" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="3" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="IDEOL" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="2" />
+            <WordsStyle name="OPERATOR" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="TARGET" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="matlab" desc="Matlab" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMAND" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="mmixal" desc="MMIXAL" ext="">
+            <WordsStyle name="CHAR" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT OTHERWISE" styleID="17" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="DIVISION BETWEEN LABEL AND OPCODE" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="DIVISION BETWEEN OPCODE AND OPERANDS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="DIVISION OF OPERANDS" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="DIVSION OF LEADING WHITESPACE IN LINE" styleID="0" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="HEXADECIMAL NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="LABEL" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPCODE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="REFERENCE (TO A LABEL)" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="REGISTER" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="STRING" styleID="12" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="SYMBOL" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="UNKNOWN OPCODE" styleID="6" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="VALID OPCODE" styleID="5" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre1" />
+        </LexerType>
+        <LexerType name="nfo" desc="Dos Style" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="nimrod" desc="Nimrod" ext="">
+            <WordsStyle name="CLASS NAME DEFINITION" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT-BLOCKS" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DECORATORS" styleID="15" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="FUNCTION OR METHOD NAME DEFINITION" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+            <WordsStyle name="HIGHLIGHTED IDENTIFIERS" styleID="14" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="IDENTIFIERS" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATORS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="SINGLE QUOTED STRING" styleID="4" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TRIPLE DOUBLE QUOTES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TRIPLE QUOTES" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="nncrontab" desc="extended crontab" ext="">
+            <WordsStyle name="ASTERISK" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="ENVIRONMENT VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="10" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2">if else for while</WordsStyle>
+            <WordsStyle name="MODIFICATORS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="2" keywordClass="type1">bool long int char</WordsStyle>
+            <WordsStyle name="NUMBER" styleID="7" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="SECTION KEYWORDS" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="TASK START/END" styleID="2" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="nsis" desc="NSIS" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="18" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="FUNCTION" styleID="5" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+            <WordsStyle name="IF DEFINE" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0">if else for while</WordsStyle>
+            <WordsStyle name="LABEL" styleID="7" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1">bool long int char</WordsStyle>
+            <WordsStyle name="MACRO" styleID="12" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="PAGE EX" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="SECTION" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+            <WordsStyle name="SECTION GROUP" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING VAR" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="SUBSECTION" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+            <WordsStyle name="USER DEFINED" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="4" keywordClass="type2" />
+            <WordsStyle name="VARIABLE" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="objc" desc="Objective-C" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0">if else for while</WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0">bool long int char</WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="DIRECTIVE" styleID="19" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="QUALIFIER" styleID="20" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="oscript" desc="OScript" ext="">
+            <WordsStyle name="#IFDEF DOC AND #ENDIF" styleID="3" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="DEFAULT TEXT STYLE" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CONSTANT LITERAL" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORDS" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="KEYWORDS" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
+            <WordsStyle name="LABEL TO JUMP TO WITH THE GOTO STATEMENT" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="LANGUAGE NATIVE KEYWORD OR RESERVED WORD" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="MULTI-LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OBJECT METHOD" styleID="18" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="OBJECT PROPERTY" styleID="17" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="OPERATOR; EITHER SYMBOLIC OR LITERAL" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR DIRECTIVE" styleID="4" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="SERVER-GLOBAL VARIABLE (PREFIXED BY $)" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="SINGLE-LINE COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="STATIC BUILT-IN OBJECT" styleID="16" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE QUOTES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING SINGLE QUOTES" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+        </LexerType>
+        <LexerType name="pascal" desc="Pascal" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ASM" styleID="14" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+            <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="HEX NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR2" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="perl" desc="Perl" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ARRAY" styleID="13" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="BACKTICKS" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DATASECTION" styleID="21" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="HASH" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="LONGQUOTE" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="POD" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PUNCTUATION" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="REGSUBST" styleID="18" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="SCALAR" styleID="12" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+        </LexerType>
+        <LexerType name="php" desc="php" ext="">
+            <WordsStyle name="DEFAULT" styleID="118" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="124" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="125" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="122" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="127" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="QUESTION MARK" styleID="18" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="119" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="VARIABLE" styleID="123" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="WORD" styleID="121" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+        </LexerType>
+        <LexerType name="postscript" desc="Postscript" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="BASE85 STRING" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DSC COMMENT" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="DSC VALUE" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="HEX STRING" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="IMMEVAL" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="LITERAL" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="NAME" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="PAREN DICT" styleID="10" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="PAREN PROC" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="TEXT" styleID="12" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="powershell" desc="PowerShell" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ALIAS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="CHARACTER" styleID="3" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CMDLET" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type4" />
+            <WordsStyle name="COMMENT STREAM" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="HERE CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="HERE STRING" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="VARIABLE" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+        </LexerType>
+        <LexerType name="props" desc="Properties file" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DEFVAL" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="SECTION" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        </LexerType>
+        <LexerType name="purebasic" desc="PureBasic" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="CONSTANT" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="python" desc="Python" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CLASSNAME" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DECORATOR" styleID="15" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+            <WordsStyle name="DEFNAME" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="F CHARACTER" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="F STRING" styleID="16" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="F TRIPLE" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORDS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TRIPLE" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="r" desc="R" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BASE WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INFIX" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING2" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="rc" desc="RC" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="rebol" desc="REBOL" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ANY OTHER TEXT" styleID="0" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+            <WordsStyle name="BINARY ( 16#{1A803F59} )" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="BLOCK COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="CHARACTERS" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="DATE { 17-FEB-2004 1/3/99 }" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="EMAIL { JOE@MAIL.DOM }" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="FILE { %/C/WINNT/SOME.DLL }" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="IDENTIFIERS" styleID="20" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="ISSUE { #123-CD-456 }" styleID="13" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="KEYWORD (ALL)" styleID="21" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD (DATATYPES)" styleID="23" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="KEYWORD (TEST FUNCTIONS)" styleID="22" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD 4" styleID="24" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="KEYWORD 5" styleID="25" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
+            <WordsStyle name="KEYWORD 6" styleID="26" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type4" />
+            <WordsStyle name="KEYWORD 7" styleID="27" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type5" />
+            <WordsStyle name="LINE COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="MONEY" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATORS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="PAIR ( 800X600 )" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREFACE" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+            <WordsStyle name="STRING WITH BRACES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING WITH QUOTES" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TAG { &lt;TITLE HEIGHT=100&gt; }" styleID="14" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="TIME { 12:30 11:22:59 01:59:59.123 }" styleID="19" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="TUPLE ( 127.0.0.1 )" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="URL { FTP://THERE.DOM }" styleID="17" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        </LexerType>
+        <LexerType name="registry" desc="registry" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="DEFAULT STYLE" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ADDED KEY" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="ESCAPED CHARACTERS IN STRINGS" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+            <WordsStyle name="GUID IN KEY PATH" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="GUID IN STRING" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="HEX DIGIT" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATORS" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="PARAMETER" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="REMOVED KEY" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="VALUE NAME" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="VALUE TYPE" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+        </LexerType>
+        <LexerType name="ruby" desc="Ruby" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BACKTICKS" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CLASS NAME" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="CLASS VAR" styleID="17" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DATA SECTION" styleID="19" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="DEF NAME" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="GLOBAL" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="MODULE NAME" styleID="15" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="POD" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING Q" styleID="24" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="SYMBOL" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="rust" desc="Rust" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BLOCK COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="BLOCK DOC COMMENT" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="BYTE CHARACTER" styleID="23" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="BYTE STRING" styleID="21" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="17" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORDS 1" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="KEYWORDS 2" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="KEYWORDS 3" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="KEYWORDS 4" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type2" />
+            <WordsStyle name="KEYWORDS 5" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type3" />
+            <WordsStyle name="KEYWORDS 6" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
+            <WordsStyle name="KEYWORDS 7" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type5" />
+            <WordsStyle name="LEXICAL ERROR" styleID="20" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="LIFETIME" styleID="18" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="LINE DOC COMMENT" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="MACRO" styleID="19" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="RAW BYTE STRING" styleID="22" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="RAW STRING" styleID="14" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="REGULAR STRING" styleID="13" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+        </LexerType>
+        <LexerType name="scheme" desc="Scheme" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD2" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="SPECIAL" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="SYMBOL" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+        </LexerType>
+        <LexerType name="searchResult" desc="Search result" ext="">
+            <WordsStyle name="Current line background colour" styleID="6" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="File Header" styleID="2" bgColor="3B4252" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="Hit Word" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="Line Number" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="Search Header" styleID="1" bgColor="3B4252" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="Selected Line" styleID="5" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="smalltalk" desc="Smalltalk" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ASSIGN" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="BINARY" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="BOOL" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="GLOBAL" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="KWS END" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="NIL" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="RETURN" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="SELF" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="SPECIAL" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="1" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="SUPER" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="SYMBOL" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+        </LexerType>
+        <LexerType name="spice" desc="spice" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="8" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="IDENTIFIERS" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="KEYWORD2" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD3" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATORS (DELIMITERS)" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+            <WordsStyle name="VALUE" styleID="7" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+        </LexerType>
+        <LexerType name="sql" desc="SQL" ext="">
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="Q OPERATOR" styleID="24" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING2" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="srec" desc="S-Record" ext="">
+            <!-- EXTENDEDADDRESS 11 N/A -->
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="DATA_EMPTY" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+            <WordsStyle name="DATA_UNKNOWN" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+            <WordsStyle name="NOADDRESS" styleID="6" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="RECCOUNT" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+        </LexerType>
+        <LexerType name="swift" desc="Swift" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+        </LexerType>
+        <LexerType name="tcl" desc="TCL" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BLOCK COMMENT" styleID="18" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT BOX" styleID="17" bgColor="2E3440" fgColor="616E88" fontStyle="1" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="EXPAND" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="IN QUOTE" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="MODIFIER" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="SUB BRACE" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="TYPE WORD" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+        </LexerType>
+        <LexerType name="tehex" desc="Tektronix extended HEX" ext="">
+            <!-- DATA_EMPTY 15 N/A -->
+            <!-- DATA_UNKNOWN 14 N/A -->
+            <!-- EXTENDEDADDRESS 11 N/A -->
+            <!-- NOADDRESS 6 N/A -->
+            <!-- RECCOUNT 8 N/A -->
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+            <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+            <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+        </LexerType>
+        <LexerType name="tex" desc="TeX" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMAND" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="GROUP" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+            <WordsStyle name="SPECIAL" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+            <WordsStyle name="SYMBOL" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="TEXT" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+        </LexerType>
+        <LexerType name="txt2tags" desc="txt2tags" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="BLOCKQUOTE" styleID="15" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="CODE" styleID="19" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="CODE2" styleID="20" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="CODEBLOCK" styleID="21" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="22" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="EM1 (ITALIC)" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+            <WordsStyle name="EM2 (UNDERLINE)" styleID="5" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="H1" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+            <WordsStyle name="H2" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+            <WordsStyle name="H3" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+            <WordsStyle name="H4" styleID="9" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+            <WordsStyle name="H5" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+            <WordsStyle name="H6" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+            <WordsStyle name="HRULE" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="LINK" styleID="18" bgColor="2E3440" fgColor="88C0D0" fontStyle="2" />
+            <WordsStyle name="LIST" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="LIST" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="OPTION" styleID="23" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="POSTPROC" styleID="25" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="PRECHAR (NOT USED)" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+            <WordsStyle name="PREPROC" styleID="24" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="SPECIAL" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRIKEOUT" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="STRONG" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+            <WordsStyle name="STRONG 2 (NOT USED)" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+        </LexerType>
+        <LexerType name="vb" desc="VB / VBS" ext="">
+            <WordsStyle name="DEFAULT" styleID="7" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DATE" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+        </LexerType>
+        <LexerType name="verilog" desc="Verilog" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="KEYWORD" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="TAGNAME" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="USER" styleID="19" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="vhdl" desc="VHDL" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="type1" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT LIne" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="INSTRUCTION" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STD FUNCTION" styleID="11" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" bgColor="2E3440" fgColor="BF616A" fontStyle="0" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type4" />
+            <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="USER DEFINE" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type5" />
+        </LexerType>
+        <LexerType name="visualprolog" desc="Visual Prolog" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ANONYMOUS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="CHARACTER" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="CHARACTER ESCAPE ERROR" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="CHARACTER TOO MANY" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT BLOCK" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="COMMENT KEY" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type2" />
+            <WordsStyle name="COMMENT KEY ERROR" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="5" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DIRECTIVE" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+            <WordsStyle name="IDENTIFIER" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+            <WordsStyle name="MAJOR" styleID="1" bgColor="2E3440" fgColor="D08770" fontStyle="0" keywordClass="instre1" />
+            <WordsStyle name="MINOR" styleID="2" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="11" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="STRING" styleID="16" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="STRING EOL OPEN" styleID="19" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING ESCAPE" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="STRING ESCAPE ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="STRING VERBATIM" styleID="20" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="STRING VERBATIM EOL" styleID="22" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="STRING VERBATIM SPECIAL" styleID="21" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+        </LexerType>
+        <LexerType name="xml" desc="XML" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="CDATA" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+            <WordsStyle name="ENTITY" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="SINGLESTRING" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+            <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="TAGEND" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="XMLEND" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="XMLSTART" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+        </LexerType>
+        <LexerType name="yaml" desc="YAML" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+            <WordsStyle name="DOCUMENT" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="ERROR" styleID="8" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+            <WordsStyle name="IDENTIFIER" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+            <WordsStyle name="REFERENCE" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+            <WordsStyle name="TEXT" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+        </LexerType>
+    </LexerStyles>
 </NotepadPlus>

--- a/src/xml/nord.xml
+++ b/src/xml/nord.xml
@@ -1,389 +1,1386 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 Copyright (c) 2016-present Arctic Ice Studio <development@arcticicestudio.com>
 Copyright (c) 2016-present Sven Greb <code@svengreb.de>
 
 Project:    Nord Notepad++
-Version:    0.1.0
+Version:    0.2.0
 Repository: https://github.com/arcticicestudio/nord-notepadplusplus
 License:    MIT
 References
-  https://developer.apple.com/xcode
+https://developer.apple.com/xcode
 -->
 <NotepadPlus>
   <GlobalStyles>
-    <WidgetStyle name="Global override" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontName="" fontSize="" fontStyle="0" />
-    <WidgetStyle name="Default Style" styleID="32" fgColor="D8DEE9" bgColor="2E3440" fontName="Source Code Pro" fontStyle="0" fontSize="16" />
-    <WidgetStyle name="Indent guideline style" styleID="37" fgColor="4C566A" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Brace highlight style" styleID="34" fgColor="D8DEE9" bgColor="88C0D0" fontStyle="0" fontSize="12" />
-    <WidgetStyle name="Bad brace colour" styleID="35" fgColor="D8DEE9" bgColor="BF616A" fontStyle="0" />
-    <WidgetStyle name="Current line background colour" styleID="0" fgColor="D8DEE9" bgColor="3B4252" fontStyle="0" />
-    <WidgetStyle name="Selected text colour" styleID="0" fgColor="D8DEE9" bgColor="434C5E" fontStyle="0" />
-    <WidgetStyle name="Caret colour" styleID="2069" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Edge colour" styleID="0" fgColor="4C566A" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Line number margin" styleID="33" fgColor="434C5E" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Fold" styleID="0" fgColor="4C566A" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Fold active" styleID="0" fgColor="88C0D0" bgColor="2E3440" fontSize="8" fontStyle="0" />
-    <WidgetStyle name="Fold margin" styleID="0" fgColor="2E3440" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="White space symbol" styleID="0" fgColor="4C566A" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Smart HighLighting" styleID="29" fgColor="D8DEE9" bgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Find Mark Style" styleID="31" fgColor="2E3440" bgColor="88C0D0" fontSize="10" fontStyle="0" />
-    <WidgetStyle name="Mark Style 1" styleID="25" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" fontSize="10" />
-    <WidgetStyle name="Mark Style 2" styleID="24" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Mark Style 3" styleID="23" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Mark Style 4" styleID="22" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" fontSize="10" />
-    <WidgetStyle name="Mark Style 5" styleID="21" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Incremental highlight all" styleID="28" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Tags match highlighting" styleID="27" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" />
-    <WidgetStyle name="Tags attribute" styleID="26" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="88C0D0" bgColor="434C5E" fontStyle="0" />
-    <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="2E3440" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Active tab text" styleID="0" fgColor="2E3440" bgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Inactive tabs" styleID="0" fgColor="2E3440" bgColor="D8DEE9" fontStyle="0" />
+    <!-- Attention : Don't modify the name of styleID="0" -->
+    <WidgetStyle name="Global override" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontSize="12" fontStyle="0" />
+    <WidgetStyle name="Default Style" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontName="Source Code Pro" fontSize="12" fontStyle="0" />
+    <WidgetStyle name="Active tab focused indicator" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+    <WidgetStyle name="Active tab text" styleID="0" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
+    <WidgetStyle name="Active tab unfocused indicator" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Bad brace colour" styleID="35" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+    <WidgetStyle name="Brace highlight style" styleID="34" bgColor="88C0D0" fgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Caret colour" styleID="2069" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Current line background colour" styleID="0" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Edge colour" styleID="0" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
+    <WidgetStyle name="Find Mark Style" styleID="31" bgColor="81A1C1" fgColor="81A1C1" fontStyle="0" />
+    <WidgetStyle name="Fold" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    <WidgetStyle name="Fold active" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+    <WidgetStyle name="Fold margin" styleID="0" bgColor="2E3440" fgColor="434C5E" fontStyle="0" />
+    <WidgetStyle name="Inactive tabs" styleID="0" bgColor="D8DEE9" fgColor="434C5E" fontStyle="0" />
+    <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="81A1C1" fgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Indent guideline style" styleID="37" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
+    <WidgetStyle name="Line number margin" styleID="33" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    <WidgetStyle name="Mark Style 1" styleID="25" bgColor="B48EAD" fgColor="B48EAD" fontStyle="0" />
+    <WidgetStyle name="Mark Style 2" styleID="24" bgColor="A3BE8C" fgColor="A3BE8C" fontStyle="0" />
+    <WidgetStyle name="Mark Style 3" styleID="23" bgColor="EBCB8B" fgColor="EBCB8B" fontStyle="0" />
+    <WidgetStyle name="Mark Style 4" styleID="22" bgColor="D08770" fgColor="D08770" fontStyle="0" />
+    <WidgetStyle name="Mark Style 5" styleID="21" bgColor="BF616A" fgColor="BF616A" fontStyle="0" />
+    <WidgetStyle name="Selected text colour" styleID="0" bgColor="434C5E" fgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="88C0D0" fgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Tags attribute" styleID="26" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+    <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+    <WidgetStyle name="URL hovered" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+    <WidgetStyle name="White space symbol" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
   </GlobalStyles>
   <LexerStyles>
-    <LexerType name="bash" desc="bash" ext="sh bsh">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="1" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="3" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="5" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="7" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="8" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SCALAR" styleID="9" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PARAM" styleID="10" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="BACKTICKS" styleID="11" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="HERE DELIM" styleID="12" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="HERE Q" styleID="13" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="actionscript" desc="ActionScript" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="FUNCTION" styleID="20" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
     </LexerType>
-    <LexerType name="batch" desc="Batch" ext="bat cmd nt">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="KEYWORDS" styleID="2" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="LABEL" styleID="3" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="HIDE SYBOL" styleID="4" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMAND" styleID="5" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="6" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="7" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="ada" desc="ADA" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="10" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DELIMITER" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="IDENTIFIER" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="ILLEGAL" styleID="11" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="1" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="LABEL" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
     </LexerType>
-    <LexerType name="c" desc="C" ext="cw">
-      <WordsStyle name="DEFAULT" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="TYPE WORD" styleID="16" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="asm" desc="Assembly" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT BLOCK" styleID="11" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="CPU INSTRUCTION" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="DIRECTIVE" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="DIRECTIVE OPERAND" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type3" />
+      <WordsStyle name="EXT INSTRUCTION" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
+      <WordsStyle name="IDENTIFIER" styleID="5" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="MATH INSTRUCTION" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="REGISTER" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
     </LexerType>
-    <LexerType name="cs" desc="C#" ext="vala">
-      <WordsStyle name="DEFAULT" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="TYPE WORD" styleID="16" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="asn1" desc="ASN.1" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ATTRIBUTES" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DESCRIPTORS" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="DOUBLE QUOTED STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="IDENTIFIERS" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+      <WordsStyle name="KEYWORDS" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
+      <WordsStyle name="NON OID NUMBERS" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="NUMERIC OID DEFINITION" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="OPERATORS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="TYPES" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type2" />
+    </LexerType>
+    <LexerType name="asp" desc="asp" ext="asp">
+      <WordsStyle name="DEFAULT" styleID="81" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ASPSYBOL" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+      <WordsStyle name="COMMENTLINE" styleID="82" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="86" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="83" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="SCRIPTTYPE" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="85" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="WORD" styleID="84" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+    </LexerType>
+    <LexerType name="autoit" desc="autoIt" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMOBJ" styleID="14" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="EXPAND" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" keywordClass="type5" />
+      <WordsStyle name="FUNCTION" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="MACRO" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type3" />
+      <WordsStyle name="SENT" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="SPECIAL" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type4" />
+      <WordsStyle name="STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="2" />
+    </LexerType>
+    <LexerType name="avs" desc="AviSynth" ext="">
+      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CLIP PROPERTIES" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" keywordClass="type3" />
+      <WordsStyle name="COMMENT: /* */" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT: [* *]" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOUBLE QUOTED STRING" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="FILTER" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="FUNCTION" styleID="12" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="IDENTIFIERS" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="LINE COMMENT: #" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATORS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PLUGIN" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="STRING WITH THREE DOUBLE QUOTES" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="USER DEFINED" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type4" />
+      <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    </LexerType>
+    <LexerType name="baanc" desc="BaanC" ext="">
+      <WordsStyle name="DEFAULT" styleID="8" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="3" />
+      <WordsStyle name="FUNCTIONS" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="KEYWORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING EOL NC" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="3" />
+    </LexerType>
+    <LexerType name="bash" desc="bash" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BACKTICKS" styleID="11" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="6" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="HERE DELIM" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="HERE Q" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PARAM" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="SCALAR" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="batch" desc="Batch" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMAND" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="HIDE SYBOL" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="KEYWORDS" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="LABEL" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="VARIABLE" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    </LexerType>
+    <LexerType name="blitzbasic" desc="BlitzBasic" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
+      <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="c" desc="C" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+    </LexerType>
+    <LexerType name="caml" desc="Caml" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="CHARACTER" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="14" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="13" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="LINENUM" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+      <WordsStyle name="NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="11" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TAGNAME" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="TYPE" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+    </LexerType>
+    <LexerType name="cmake" desc="CMakeFile" ext="cmake">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMAND" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="FOREACHDEF" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+      <WordsStyle name="IFDEF" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+      <WordsStyle name="MACRODEF" styleID="12" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="PARAMETER" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="STRING D" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING L" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="2" />
+      <WordsStyle name="STRING R" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="4" />
+      <WordsStyle name="STRING VARIABLE" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+      <WordsStyle name="USER DEFINED" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="VARIABLE" styleID="7" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="WHILEDEF" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+    </LexerType>
+    <LexerType name="cobol" desc="COBOL" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="DECLARATION" styleID="5" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="KEYWORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="coffeescript" desc="CoffeeScript" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT BLOCK" styleID="22" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREDEFINED CONSTANT" styleID="19" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type2" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="VERBOSE REGEX" styleID="23" bgColor="2E3440" fgColor="B48EAD" fontStyle="3" />
+      <WordsStyle name="VERBOSE REGEX COMMENT" styleID="24" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
     </LexerType>
     <LexerType name="cpp" desc="C++" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="TYPE WORD" styleID="16" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+    </LexerType>
+    <LexerType name="cs" desc="C#" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+    </LexerType>
+    <LexerType name="csound" desc="Csound" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="A-RATE VARIABLE" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT BLOCK" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="GLOBAL VARIABLE" styleID="14" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="HEADER STATEMENT" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="IDENTIFIER" styleID="5" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTR" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="I-RATE VARIABLE" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="K-RATE VARIABLE" styleID="12" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPCODE" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="OPERATOR" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PARAMETER" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+      <WordsStyle name="USER KEYWORDS" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
     </LexerType>
     <LexerType name="css" desc="CSS" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TAG" styleID="1" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CLASS" styleID="2" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="8FBCBB" bgColor="2E3440" fontStyle="2" />
-      <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="6" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" strikethrough="1" />
-      <WordsStyle name="VALUE" styleID="8" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="9" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ID" styleID="10" fgColor="8FBCBB" bgColor="2E3440" fontStyle="2" />
-      <WordsStyle name="IMPORTANT" styleID="11" fgColor="81A1C1" bgColor="2E3440" fontStyle="1" />
-      <WordsStyle name="DIRECTIVE" styleID="12" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DOUBLESTRING" styleID="13" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SINGLESTRING" styleID="14" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CLASS" styleID="2" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DIRECTIVE" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="ID" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="IMPORTANT" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PSEUDOCLASS" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="VALUE" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+    </LexerType>
+    <LexerType name="d" desc="D" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="17" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT NESTED" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="14" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="KEWORD1" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="KEWORD2" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="KEWORD3" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="KEWORD4" styleID="20" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
+      <WordsStyle name="KEWORD5" styleID="21" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type4" />
+      <WordsStyle name="KEWORD6" styleID="22" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type5" />
+      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING B" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING R" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="diff" desc="DIFF" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ADDED" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="COMMAND" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DELETED" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="HEADER" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="POSITION" styleID="4" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+    </LexerType>
+    <LexerType name="erlang" desc="Erlang" ext="">
+      <WordsStyle name="DEFAULT COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DEFAULT STYLE" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ATOM" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="ATOM QUOTED" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="BUILT-IN FUNCTIONS" styleID="22" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="CHARACTER" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="DOCUMENTATION HELPER IN COMMENT" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type3" />
+      <WordsStyle name="DOCUMENTATION MACRO IN COMMENT" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="3" keywordClass="type4" />
+      <WordsStyle name="FUNCTION NAME" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="FUNCTION COMMENT" styleID="14" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="MACRO" styleID="10" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="MACRO QUOTED" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="MODULE ATTRIBUTES" styleID="24" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="MODULE COMMENT" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="MODULE NAME" styleID="23" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="NODE NAME" styleID="13" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="NODE NAME QUOTED" styleID="21" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATORS" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="RECORD" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+      <WordsStyle name="RECORD QUOTED" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+      <WordsStyle name="RESERVED WORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="UNKNOWN: ERROR" styleID="31" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="VARIABLE" styleID="2" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    </LexerType>
+    <LexerType name="escript" desc="ESCRIPT" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BRACES" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOC COMMENT" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="DOUBLE QUOTED STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="IDENTIFIERS" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="KEYWORDS2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="KEYWORDS3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATORS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+    </LexerType>
+    <LexerType name="forth" desc="Forth" ext="">
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="CONTROL" styleID="4" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="DEFWORDS" styleID="6" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="DOUBLE QUOTED STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" keywordClass="type4" />
+      <WordsStyle name="IDENTIFIER" styleID="3" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+      <WordsStyle name="KEYWORDS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="LOCALE" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="ML COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="PREWORD1" styleID="7" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type2" />
+      <WordsStyle name="PREWORD2" styleID="8" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type3" />
+      <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    </LexerType>
+    <LexerType name="fortran" desc="Fortran (free form)" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="CONTINUATION" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="FUNCTION1" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="FUNCTION2" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="LABEL" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="OPERATOR2" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING2" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+    </LexerType>
+    <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="CONTINUATION" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="FUNCTION1" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="FUNCTION2" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="LABEL" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="OPERATOR2" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING2" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+    </LexerType>
+    <LexerType name="freebasic" desc="FreeBasic" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0">endfunction endif</WordsStyle>
+      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="gui4cli" desc="GUI4CLI" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ATTRIBUTE" styleID="16" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="COMMAND" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type3" />
+      <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="CONTROL" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="EVENT" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="GLOBAL" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
     </LexerType>
     <LexerType name="haskell" desc="Haskell" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="2" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="3" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="4" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="5" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CLASS" styleID="6" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="MODULE" styleID="7" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CAPITAL" styleID="8" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DATA" styleID="9" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IMPORT" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="11" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTANCE" styleID="12" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="13" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CAPITAL" styleID="8" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CLASS" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="COMMENTBLOCK" styleID="14" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTBLOCK2" styleID="15" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTBLOCK3" styleID="16" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="13" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DATA" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="IMPORT" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="INSTANCE" styleID="12" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="MODULE" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
     </LexerType>
-    <LexerType name="diff" desc="diff" ext="diff patch">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMAND" styleID="2" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="HEADER" styleID="3" fgColor="88C0D0" bgColor="2E3440" fontStyle="1" />
-      <WordsStyle name="POSITION" styleID="4" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DELETED" styleID="5" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ADDED" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="html" desc="HTML" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ATTRIBUTE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="CDATA" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOUBLESTRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="ENTITY" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="SGMLDEFAULT" styleID="21" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="SINGLESTRING" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="TAGEND" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="TAGUNKNOWN" styleID="2" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="VALUE" styleID="19" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
     </LexerType>
-    <LexerType name="html" desc="HTML" ext="html htm shtml shtm xhtml hta">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="9" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="5" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SINGLESTRING" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TAG" styleID="1" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TAGEND" styleID="11" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CDATA" styleID="17" fgColor="616E88" bgColor="2E3440" fontStyle="1" />
-      <WordsStyle name="VALUE" styleID="19" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ENTITY" styleID="10" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="ihex" desc="Intel HEX" ext="">
+      <!-- RECCOUNT 8 N/A -->
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="DATA_EMPTY" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+      <WordsStyle name="DATA_UNKNOWN" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="EXTENDEDADDRESS" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+      <WordsStyle name="NOADDRESS" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
     </LexerType>
-    <LexerType name="ini" desc="Initialization file" ext="ini inf reg url">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SECTION" styleID="2" fgColor="81A1C1" bgColor="2E3440" fontStyle="1" />
-      <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="88C0D0" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DEFVAL" styleID="4" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="ini" desc="ini file" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ASSIGNMENT" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DEFVAL" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="SECTION" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
     </LexerType>
-    <LexerType name="java" desc="Java" ext="java">
-      <WordsStyle name="DEFAULT" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="TYPE WORD" styleID="16" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="VERBATIM" styleID="13" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="14" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="inno" desc="InnoSetup" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT PASCAL" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="KEYWORD PASCAL" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type3" />
+      <WordsStyle name="KEYWORD USER" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
+      <WordsStyle name="PARAMETER" styleID="3" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR INLINE" styleID="6" bgColor="2E3440" fgColor="D08770" fontStyle="1" />
+      <WordsStyle name="SECTION" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="STRING DOUBLE" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING SINGLE" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
     </LexerType>
-    <LexerType name="javascript" desc="Javascript" ext="js json">
-      <WordsStyle name="DEFAULT" styleID="41" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="45" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="WORD" styleID="46" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="47" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SINGLESTRING" styleID="49" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SYMBOLS" styleID="50" fgColor="ECEFF4" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRINGEOL" styleID="51" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="52" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="42" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="43" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTDOC" styleID="44" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="java" desc="Java" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+    </LexerType>
+    <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
+      <WordsStyle name="DEFAULT" styleID="41" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="42" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTDOC" styleID="44" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="43" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOUBLESTRING" styleID="48" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="47" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="45" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="52" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="SINGLESTRING" styleID="49" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="SYMBOLS" styleID="50" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="WORD" styleID="46" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+    </LexerType>
+    <LexerType name="javascript.js" desc="JavaScript" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="FFFFFF" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0">True False</WordsStyle>
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRINGRAW" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="WINDOW INSTRUCTION" styleID="19" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
     </LexerType>
     <LexerType name="json" desc="JSON" ext="">
-      <WordsStyle name="DEFAULT" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING DOUBLE QUOTE" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING SINGLE QUOTE" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="BOOLEAN NULL" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BOOLEAN NULL" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING DOUBLE QUOTE" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING SINGLE QUOTE" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+    </LexerType>
+    <LexerType name="kix" desc="KiXtart" ext="">
+      <WordsStyle name="DEFAULT" styleID="31" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="FUNCTION" styleID="8" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="MACRO" styleID="6" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0">if else for while</WordsStyle>
+      <WordsStyle name="OPERATOR" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0">bool long int char</WordsStyle>
+      <WordsStyle name="STRING" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING2" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="VAR" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    </LexerType>
+    <LexerType name="latex" desc="LaTeX" ext="">
+      <WordsStyle name="COMMAND" styleID="1" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="COMMAND OPTIONAL ARGUMENT" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT BLOCK" styleID="7" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="MATH BLOCK" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="MATH INLINE" styleID="3" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="SHORT COMMAND" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="SPECIAL CHAR" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="SYNTAX ERROR" styleID="12" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="TAG CLOSING" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="TAG OPENING" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="VERBATIM SEGMENT" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    </LexerType>
+    <LexerType name="lisp" desc="LISP" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="FUNCTION WORD" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="FUNCTION WORD2" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="SPECIAL" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="SYMBOL" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
     </LexerType>
     <LexerType name="lua" desc="Lua" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="LITERALSTRING" styleID="8" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="FUNC1" styleID="13" fgColor="88C0D0" bgColor="2E3440" fontStyle="0" keywordClass="instre2" />
-      <WordsStyle name="FUNC2" styleID="14" fgColor="88C0D0" bgColor="2E3440" fontStyle="0" keywordClass="type1" />
-      <WordsStyle name="FUNC3" styleID="15" fgColor="88C0D0" bgColor="2E3440" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="FUNC1" styleID="13" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="FUNC2" styleID="14" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="FUNC3" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="LABEL" styleID="20" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="LITERALSTRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
     </LexerType>
-    <LexerType name="php" desc="PHP" ext="php php3 phtml">
-      <WordsStyle name="DEFAULT" styleID="118" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="QUESTION MARK" styleID="18" fgColor="81A1C1" bgColor="2E3440" fontStyle="1" />
-      <WordsStyle name="STRING" styleID="119" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="WORD" styleID="121" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="NUMBER" styleID="122" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="VARIABLE" styleID="123" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="124" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="125" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="127" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="makefile" desc="Makefile" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="3" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="IDEOL" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="2" />
+      <WordsStyle name="OPERATOR" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="PREPROCESSOR" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="TARGET" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+    </LexerType>
+    <LexerType name="matlab" desc="Matlab" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMAND" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="mmixal" desc="MMIXAL" ext="">
+      <WordsStyle name="CHAR" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT OTHERWISE" styleID="17" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="DIVISION BETWEEN LABEL AND OPCODE" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="DIVISION BETWEEN OPCODE AND OPERANDS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="DIVISION OF OPERANDS" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="DIVSION OF LEADING WHITESPACE IN LINE" styleID="0" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="HEXADECIMAL NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="LABEL" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPCODE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="REFERENCE (TO A LABEL)" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="REGISTER" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="STRING" styleID="12" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="SYMBOL" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="UNKNOWN OPCODE" styleID="6" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="VALID OPCODE" styleID="5" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="instre1" />
+    </LexerType>
+    <LexerType name="nfo" desc="Dos Style" ext="">
+      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    </LexerType>
+    <LexerType name="nimrod" desc="Nimrod" ext="">
+      <WordsStyle name="CLASS NAME DEFINITION" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT-BLOCKS" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DECORATORS" styleID="15" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="FUNCTION OR METHOD NAME DEFINITION" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+      <WordsStyle name="HIGHLIGHTED IDENTIFIERS" styleID="14" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="IDENTIFIERS" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATORS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="SINGLE QUOTED STRING" styleID="4" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TRIPLE DOUBLE QUOTES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TRIPLE QUOTES" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="WHITE SPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    </LexerType>
+    <LexerType name="nncrontab" desc="extended crontab" ext="">
+      <WordsStyle name="ASTERISK" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOUBLE QUOTED STRING" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="ENVIRONMENT VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="10" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORDS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2">if else for while</WordsStyle>
+      <WordsStyle name="MODIFICATORS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="2" keywordClass="type1">bool long int char</WordsStyle>
+      <WordsStyle name="NUMBER" styleID="7" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="SECTION KEYWORDS" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="TASK START/END" styleID="2" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    </LexerType>
+    <LexerType name="nsis" desc="NSIS" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="18" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="FUNCTION" styleID="5" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" keywordClass="instre1" />
+      <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+      <WordsStyle name="IF DEFINE" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0">if else for while</WordsStyle>
+      <WordsStyle name="LABEL" styleID="7" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1">bool long int char</WordsStyle>
+      <WordsStyle name="MACRO" styleID="12" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="NUMBER" styleID="14" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="PAGE EX" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="SECTION" styleID="9" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+      <WordsStyle name="SECTION GROUP" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+      <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING LEFT QUOTE" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING RIGHT QUOTE" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING VAR" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="SUBSECTION" styleID="10" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" />
+      <WordsStyle name="USER DEFINED" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="4" keywordClass="type2" />
+      <WordsStyle name="VARIABLE" styleID="6" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    </LexerType>
+    <LexerType name="objc" desc="Objective-C" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0">if else for while</WordsStyle>
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0">bool long int char</WordsStyle>
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="DIRECTIVE" styleID="19" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="QUALIFIER" styleID="20" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+    </LexerType>
+    <LexerType name="oscript" desc="OScript" ext="">
+      <WordsStyle name="#IFDEF DOC AND #ENDIF" styleID="3" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="DEFAULT TEXT STYLE" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CONSTANT LITERAL" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORDS" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="KEYWORDS" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
+      <WordsStyle name="LABEL TO JUMP TO WITH THE GOTO STATEMENT" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="LANGUAGE NATIVE KEYWORD OR RESERVED WORD" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="MULTI-LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OBJECT METHOD" styleID="18" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="OBJECT PROPERTY" styleID="17" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="OPERATOR; EITHER SYMBOLIC OR LITERAL" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="PREPROCESSOR DIRECTIVE" styleID="4" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="SERVER-GLOBAL VARIABLE (PREFIXED BY $)" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="SINGLE-LINE COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="STATIC BUILT-IN OBJECT" styleID="16" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" keywordClass="type4" />
+      <WordsStyle name="STRING DOUBLE QUOTES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING SINGLE QUOTES" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+    </LexerType>
+    <LexerType name="pascal" desc="Pascal" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ASM" styleID="14" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+      <WordsStyle name="CHARACTER" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="HEX NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="NUMBER" styleID="7" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR2" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="10" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="perl" desc="Perl" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ARRAY" styleID="13" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="BACKTICKS" styleID="20" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DATASECTION" styleID="21" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="HASH" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="LONGQUOTE" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="POD" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PUNCTUATION" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="REGSUBST" styleID="18" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="SCALAR" styleID="12" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="SYMBOL TABLE" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+    </LexerType>
+    <LexerType name="php" desc="php" ext="">
+      <WordsStyle name="DEFAULT" styleID="118" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="124" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="125" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="122" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="127" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="QUESTION MARK" styleID="18" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="SIMPLESTRING" styleID="120" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="119" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING VARIABLE" styleID="126" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="VARIABLE" styleID="123" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="WORD" styleID="121" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
     </LexerType>
     <LexerType name="postscript" desc="Postscript" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DSC COMMENT" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DSC VALUE" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION" styleID="6" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="LITERAL" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IMMEVAL" styleID="8" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="ECEFF4" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PAREN DICT" styleID="10" fgColor="ECEFF4" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PAREN PROC" styleID="11" fgColor="ECEFF4" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TEXT" styleID="12" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="HEX STRING" styleID="13" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="BASE85 STRING" styleID="14" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BAD STRING CHAR" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="BASE85 STRING" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DSC COMMENT" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="DSC VALUE" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="HEX STRING" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="IMMEVAL" styleID="8" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="LITERAL" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="NAME" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="PAREN ARRAY" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="PAREN DICT" styleID="10" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="PAREN PROC" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="TEXT" styleID="12" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
     </LexerType>
-    <LexerType name="props" desc="Properties file" ext="properties">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SECTION" styleID="2" fgColor="81A1C1" bgColor="2E3440" fontStyle="1" />
-      <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="88C0D0" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DEFVAL" styleID="4" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="powershell" desc="PowerShell" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ALIAS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="CHARACTER" styleID="3" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CMDLET" styleID="9" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type4" />
+      <WordsStyle name="COMMENT STREAM" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="HERE CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="HERE STRING" styleID="14" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="2" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="VARIABLE" styleID="5" bgColor="2E3440" fgColor="D8DEE9" fontStyle="1" />
+    </LexerType>
+    <LexerType name="props" desc="Properties file" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ASSIGNMENT" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DEFVAL" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="SECTION" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+    </LexerType>
+    <LexerType name="purebasic" desc="PureBasic" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BINNUMBER" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="CONSTANT" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="ERROR" styleID="16" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="HEXNUMBER" styleID="17" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD1" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre1" />
+      <WordsStyle name="KEYWORD2" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="KEYWORD3" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="KEYWORD4" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="LABEL" styleID="15" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
     </LexerType>
     <LexerType name="python" desc="Python" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING" styleID="3" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="4" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="KEYWORDS" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="TRIPLE" styleID="6" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CLASSNAME" styleID="8" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DEFNAME" styleID="9" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRINGEOL" styleID="12" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CLASSNAME" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="COMMENTBLOCK" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DECORATOR" styleID="15" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+      <WordsStyle name="DEFNAME" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="F CHARACTER" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="F STRING" styleID="16" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="F TRIPLE" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="F TRIPLEDOUBLE" styleID="19" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORDS" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TRIPLE" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TRIPLEDOUBLE" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="r" desc="R" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BASE WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INFIX" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="KEYWORD" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING2" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="rc" desc="RC" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+    </LexerType>
+    <LexerType name="rebol" desc="REBOL" ext="">
+      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ANY OTHER TEXT" styleID="0" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+      <WordsStyle name="BINARY ( 16#{1A803F59} )" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="BLOCK COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="CHARACTERS" styleID="5" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="DATE { 17-FEB-2004 1/3/99 }" styleID="18" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="EMAIL { JOE@MAIL.DOM }" styleID="16" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="FILE { %/C/WINNT/SOME.DLL }" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="IDENTIFIERS" styleID="20" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="ISSUE { #123-CD-456 }" styleID="13" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="KEYWORD (ALL)" styleID="21" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="KEYWORD (DATATYPES)" styleID="23" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="KEYWORD (TEST FUNCTIONS)" styleID="22" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="KEYWORD 4" styleID="24" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="KEYWORD 5" styleID="25" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type3" />
+      <WordsStyle name="KEYWORD 6" styleID="26" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type4" />
+      <WordsStyle name="KEYWORD 7" styleID="27" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type5" />
+      <WordsStyle name="LINE COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="MONEY" styleID="12" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATORS" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="PAIR ( 800X600 )" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREFACE" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+      <WordsStyle name="STRING WITH BRACES" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING WITH QUOTES" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TAG { &lt;TITLE HEIGHT=100&gt; }" styleID="14" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="TIME { 12:30 11:22:59 01:59:59.123 }" styleID="19" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="TUPLE ( 127.0.0.1 )" styleID="10" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="URL { FTP://THERE.DOM }" styleID="17" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+    </LexerType>
+    <LexerType name="registry" desc="registry" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="DEFAULT STYLE" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ADDED KEY" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="ESCAPED CHARACTERS IN STRINGS" styleID="8" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+      <WordsStyle name="GUID IN KEY PATH" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="GUID IN STRING" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="HEX DIGIT" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATORS" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="PARAMETER" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="REMOVED KEY" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="VALUE NAME" styleID="2" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="VALUE TYPE" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
     </LexerType>
     <LexerType name="ruby" desc="Ruby" ext="">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ERROR" styleID="1" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENTLINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="POD" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTRUCTION" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="STRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CHARACTER" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CLASS NAME" styleID="8" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DEF NAME" styleID="9" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="REGEX" styleID="12" fgColor="EBCB8B" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="GLOBAL" styleID="13" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SYMBOL" styleID="14" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="MODULE NAME" styleID="15" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CLASS VAR" styleID="17" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="BACKTICKS" styleID="18" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DATA SECTION" styleID="19" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING Q" styleID="24" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BACKTICKS" styleID="18" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CLASS NAME" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="CLASS VAR" styleID="17" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DATA SECTION" styleID="19" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="DEF NAME" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="ERROR" styleID="1" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="GLOBAL" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTANCE VAR" styleID="16" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="MODULE NAME" styleID="15" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="POD" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING Q" styleID="24" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="SYMBOL" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
     </LexerType>
-    
+    <LexerType name="rust" desc="Rust" ext="">
+      <WordsStyle name="DEFAULT" styleID="32" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BLOCK COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="BLOCK DOC COMMENT" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="BYTE CHARACTER" styleID="23" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="BYTE STRING" styleID="21" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="17" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORDS 1" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="KEYWORDS 2" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="KEYWORDS 3" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="KEYWORDS 4" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type2" />
+      <WordsStyle name="KEYWORDS 5" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type3" />
+      <WordsStyle name="KEYWORDS 6" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type4" />
+      <WordsStyle name="KEYWORDS 7" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="type5" />
+      <WordsStyle name="LEXICAL ERROR" styleID="20" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="LIFETIME" styleID="18" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="LINE COMMENT" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="LINE DOC COMMENT" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="MACRO" styleID="19" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="16" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="RAW BYTE STRING" styleID="22" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="RAW STRING" styleID="14" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="REGULAR STRING" styleID="13" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="WHITESPACE" styleID="0" bgColor="2E3440" fgColor="4C566A" fontStyle="0" />
+    </LexerType>
+    <LexerType name="scheme" desc="Scheme" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="12" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENTLINE" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="FUNCTION WORD" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="FUNCTION WORD2" styleID="4" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="IDENTIFIER" styleID="9" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="SPECIAL" styleID="11" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="SYMBOL" styleID="5" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+    </LexerType>
     <LexerType name="searchResult" desc="Search result" ext="">
-      <WordsStyle name="Default" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="Search Header" styleID="1" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="File Header" styleID="2" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="Line Number" styleID="3" fgColor="4C566A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="Hit Word" styleID="4" fgColor="2E3440" bgColor="88C0D0" fontStyle="0" />
-      <WordsStyle name="Selected Line" styleID="5" fgColor="D8DEE9" bgColor="3B4252" fontStyle="0" />
-      <WordsStyle name="Current line background colour" styleID="6" bgColor="3B4252" fontStyle="0" />
+      <WordsStyle name="Current line background colour" styleID="6" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="File Header" styleID="2" bgColor="3B4252" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="Hit Word" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="Line Number" styleID="3" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="Search Header" styleID="1" bgColor="3B4252" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="Selected Line" styleID="5" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />
     </LexerType>
-    
-    <LexerType name="sql" desc="SQL" ext="sql">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT DOC" styleID="3" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="STRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="STRING2" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="10" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="smalltalk" desc="Smalltalk" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ASSIGN" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="BINARY" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="BOOL" styleID="6" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="15" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="3" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="GLOBAL" styleID="10" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="KWS END" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="NIL" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="RETURN" styleID="11" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="SELF" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="SPECIAL" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="SPECIAL SELECTOR" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="1" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="SUPER" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="SYMBOL" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="1" />
+    </LexerType>
+    <LexerType name="spice" desc="spice" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="8" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="IDENTIFIERS" styleID="1" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="2" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="KEYWORD2" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="KEYWORD3" styleID="4" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATORS (DELIMITERS)" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" />
+      <WordsStyle name="VALUE" styleID="7" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+    </LexerType>
+    <LexerType name="sql" desc="SQL" ext="">
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="Q OPERATOR" styleID="24" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING2" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="srec" desc="S-Record" ext="">
+      <!-- EXTENDEDADDRESS 11 N/A -->
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="DATA_EMPTY" styleID="15" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+      <WordsStyle name="DATA_UNKNOWN" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+      <WordsStyle name="NOADDRESS" styleID="6" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="RECCOUNT" styleID="8" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+    </LexerType>
+    <LexerType name="swift" desc="Swift" ext="">
+      <WordsStyle name="DEFAULT" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="7" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE DOC" styleID="15" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="REGEX" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="16" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="VERBATIM" styleID="13" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+    </LexerType>
+    <LexerType name="tcl" desc="TCL" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BLOCK COMMENT" styleID="18" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT BOX" styleID="17" bgColor="2E3440" fgColor="616E88" fontStyle="1" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="EXPAND" styleID="11" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="7" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="IN QUOTE" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="MODIFIER" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="SUB BRACE" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="SUBSTITUTION" styleID="8" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="TYPE WORD" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="WORD IN QUOTE" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
+    </LexerType>
+    <LexerType name="tehex" desc="Tektronix extended HEX" ext="">
+      <!-- DATA_EMPTY 15 N/A -->
+      <!-- DATA_UNKNOWN 14 N/A -->
+      <!-- EXTENDEDADDRESS 11 N/A -->
+      <!-- NOADDRESS 6 N/A -->
+      <!-- RECCOUNT 8 N/A -->
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="BYTECOUNT" styleID="4" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="BYTECOUNT_WRONG" styleID="5" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="CHECKSUM" styleID="16" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CHECKSUM_WRONG" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="DATA_EVEN" styleID="13" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="DATA_ODD" styleID="12" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+      <WordsStyle name="DATAADDRESS" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="GARBAGE" styleID="18" bgColor="2E3440" fgColor="D08770" fontStyle="2" />
+      <WordsStyle name="RECSTART" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="RECTYPE" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="STARTADDRESS" styleID="9" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+    </LexerType>
+    <LexerType name="tex" desc="TeX" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMAND" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="GROUP" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="1" />
+      <WordsStyle name="SPECIAL" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+      <WordsStyle name="SYMBOL" styleID="3" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="TEXT" styleID="5" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+    </LexerType>
+    <LexerType name="txt2tags" desc="txt2tags" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="BLOCKQUOTE" styleID="15" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="CODE" styleID="19" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="CODE2" styleID="20" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="CODEBLOCK" styleID="21" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="22" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="EM1 (ITALIC)" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="2" />
+      <WordsStyle name="EM2 (UNDERLINE)" styleID="5" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="H1" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+      <WordsStyle name="H2" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+      <WordsStyle name="H3" styleID="8" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+      <WordsStyle name="H4" styleID="9" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+      <WordsStyle name="H5" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+      <WordsStyle name="H6" styleID="11" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" />
+      <WordsStyle name="HRULE" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="LINK" styleID="18" bgColor="2E3440" fgColor="88C0D0" fontStyle="2" />
+      <WordsStyle name="LIST" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="LIST" styleID="14" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="OPTION" styleID="23" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="POSTPROC" styleID="25" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="PRECHAR (NOT USED)" styleID="12" bgColor="2E3440" fgColor="EBCB8B" fontStyle="1" />
+      <WordsStyle name="PREPROC" styleID="24" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="SPECIAL" styleID="1" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRIKEOUT" styleID="16" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="STRONG" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="1" />
+      <WordsStyle name="STRONG 2 (NOT USED)" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
     </LexerType>
     <LexerType name="vb" desc="VB / VBS" ext="">
-      <WordsStyle name="DEFAULT" styleID="7" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="2" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="WORD" styleID="3" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" keywordClass="instre1" />
-      <WordsStyle name="STRING" styleID="4" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="6" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DATE" styleID="8" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
+      <WordsStyle name="DEFAULT" styleID="7" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DATE" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="2" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="5" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
     </LexerType>
-    <LexerType name="xml" desc="XML" ext="xml xsml xsl xsd kml wsdl xlf xliff">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="XMLSTART" styleID="12" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="XMLEND" styleID="13" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="9" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="5" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SINGLESTRING" styleID="7" fgColor="A3BE8C" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TAG" styleID="1" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TAGEND" styleID="11" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="BF616A" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="CDATA" styleID="17" fgColor="616E88" bgColor="2E3440" fontStyle="1" />
+    <LexerType name="verilog" desc="Verilog" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE BANG" styleID="3" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="11" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="KEYWORD" styleID="7" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="PREPROCESSOR" styleID="9" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="TAGNAME" styleID="2" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="USER" styleID="19" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
     </LexerType>
-    <LexerType name="yaml" desc="YAML" ext="yaml">
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="COMMENT" styleID="1" fgColor="616E88" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="KEY" styleID="2" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="KEYWORD" styleID="3" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="NUMBER" styleID="4" fgColor="B48EAD" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="REFERENCE" styleID="5" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="DOCUMENT HEADER" styleID="6" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="SCALAR" styleID="7" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="TEXT" styleID="8" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
-      <WordsStyle name="OPERATOR" styleID="9" fgColor="81A1C1" bgColor="2E3440" fontStyle="0" />
+    <LexerType name="vhdl" desc="VHDL" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ATTRIBUTE" styleID="10" bgColor="2E3440" fgColor="8FBCBB" fontStyle="1" keywordClass="type1" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT LIne" styleID="2" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="6" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="INSTRUCTION" styleID="8" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="NUMBER" styleID="3" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STD FUNCTION" styleID="11" bgColor="2E3440" fgColor="88C0D0" fontStyle="1" keywordClass="type2" />
+      <WordsStyle name="STD OPERATOR" styleID="9" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre2" />
+      <WordsStyle name="STD PACKAGE" styleID="12" bgColor="2E3440" fgColor="BF616A" fontStyle="0" keywordClass="type3" />
+      <WordsStyle name="STD TYPE" styleID="13" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type4" />
+      <WordsStyle name="STRING" styleID="4" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="USER DEFINE" styleID="14" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="type5" />
+    </LexerType>
+    <LexerType name="visualprolog" desc="Visual Prolog" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ANONYMOUS" styleID="10" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="CHARACTER" styleID="13" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="CHARACTER ESCAPE ERROR" styleID="15" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="CHARACTER TOO MANY" styleID="14" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT BLOCK" styleID="4" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="COMMENT KEY" styleID="6" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" keywordClass="type2" />
+      <WordsStyle name="COMMENT KEY ERROR" styleID="7" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="COMMENT LINE" styleID="5" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DIRECTIVE" styleID="3" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" keywordClass="type1" />
+      <WordsStyle name="IDENTIFIER" styleID="8" bgColor="2E3440" fgColor="ECEFF4" fontStyle="0" />
+      <WordsStyle name="MAJOR" styleID="1" bgColor="2E3440" fgColor="D08770" fontStyle="0" keywordClass="instre1" />
+      <WordsStyle name="MINOR" styleID="2" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" keywordClass="instre2" />
+      <WordsStyle name="NUMBER" styleID="11" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="OPERATOR" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="STRING" styleID="16" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="STRING EOL OPEN" styleID="19" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING ESCAPE" styleID="17" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="STRING ESCAPE ERROR" styleID="18" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="STRING VERBATIM" styleID="20" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="STRING VERBATIM EOL" styleID="22" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="STRING VERBATIM SPECIAL" styleID="21" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="VARIABLE" styleID="9" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+    </LexerType>
+    <LexerType name="xml" desc="XML" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="ATTRIBUTE" styleID="3" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="CDATA" styleID="17" bgColor="2E3440" fgColor="D08770" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="9" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOUBLESTRING" styleID="6" bgColor="2E3440" fgColor="A3BE8C" fontStyle="0" />
+      <WordsStyle name="ENTITY" styleID="10" bgColor="2E3440" fgColor="EBCB8B" fontStyle="0" />
+      <WordsStyle name="NUMBER" styleID="5" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="SGMLDEFAULT" styleID="21" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="SINGLESTRING" styleID="7" bgColor="2E3440" fgColor="8FBCBB" fontStyle="0" />
+      <WordsStyle name="TAG" styleID="1" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="TAGEND" styleID="11" bgColor="2E3440" fgColor="5E81AC" fontStyle="0" />
+      <WordsStyle name="TAGUNKNOWN" styleID="2" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="XMLEND" styleID="13" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="XMLSTART" styleID="12" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+    </LexerType>
+    <LexerType name="yaml" desc="YAML" ext="">
+      <WordsStyle name="DEFAULT" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
+      <WordsStyle name="COMMENT" styleID="1" bgColor="2E3440" fgColor="616E88" fontStyle="0" />
+      <WordsStyle name="DOCUMENT" styleID="6" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="ERROR" styleID="8" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+      <WordsStyle name="IDENTIFIER" styleID="2" bgColor="2E3440" fgColor="ECEFF4" fontStyle="1" />
+      <WordsStyle name="INSTRUCTION WORD" styleID="3" bgColor="2E3440" fgColor="81A1C1" fontStyle="1" keywordClass="instre1" />
+      <WordsStyle name="NUMBER" styleID="4" bgColor="2E3440" fgColor="B48EAD" fontStyle="0" />
+      <WordsStyle name="REFERENCE" styleID="5" bgColor="2E3440" fgColor="81A1C1" fontStyle="0" />
+      <WordsStyle name="TEXT" styleID="7" bgColor="2E3440" fgColor="A3BE8C" fontStyle="1" />
     </LexerType>
   </LexerStyles>
 </NotepadPlus>

--- a/src/xml/nord.xml
+++ b/src/xml/nord.xml
@@ -18,7 +18,7 @@ https://developer.apple.com/xcode
     <WidgetStyle name="Active tab focused indicator" styleID="0" bgColor="2E3440" fgColor="88C0D0" fontStyle="0" />
     <WidgetStyle name="Active tab text" styleID="0" bgColor="2E3440" fgColor="3B4252" fontStyle="0" />
     <WidgetStyle name="Active tab unfocused indicator" styleID="0" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Bad brace colour" styleID="35" bgColor="2E3440" fgColor="BF616A" fontStyle="0" />
+    <WidgetStyle name="Bad brace colour" styleID="35" bgColor="BF616A" fgColor="2E3440" fontStyle="0" />
     <WidgetStyle name="Brace highlight style" styleID="34" bgColor="88C0D0" fgColor="D8DEE9" fontStyle="0" />
     <WidgetStyle name="Caret colour" styleID="2069" bgColor="2E3440" fgColor="D8DEE9" fontStyle="0" />
     <WidgetStyle name="Current line background colour" styleID="0" bgColor="4C566A" fgColor="D8DEE9" fontStyle="0" />


### PR DESCRIPTION
This version of the theme reflects all the languages available in the Notepad++ styler as of version 7.7.1.

It includes the following languages: ActionScript, ADA, Assembly, ASN.1, asp, autoIt, AviSynth, BaanC, bash, Batch, BlitzBasic, C, Caml, CMakeFile, COBOL, CoffeeScript, C++, C#, Csound, CSS, D, DIFF, Erlang, ESCRIPT, Forth, Fortran (free form), Fortran (fixed form), FreeBasic, GUI4CLI, Haskell, HTML, Intel HEX, ini file, InnoSetup, Java, JavaScript (embedded), JavaScript, JSON, KiXtart, LaTeX, LISP, Lua, Makefile, Matlab, MMIXAL, Dos Style, Nimrod, extended crontab, NSIS, Objective-C, OScript, Pascal, Perl, php, Postscript, PowerShell, Properties file, PureBasic, Python, R, RC, REBOL, registry, Ruby, Rust, Scheme, Search result, Smalltalk, spice, SQL, S-Record, Swift, TCL, Tektronix extended HEX, TeX, txt2tags, VB / VBS, Verilog, VHDL, Visual Prolog, XML, YAML

I did my best to get it to match as close as possible to what is available with the Nord theme for VS Code.