### PR TITLE
Fix tabs background and foreground

### DIFF
--- a/src/xml/nord.xml
+++ b/src/xml/nord.xml
@@ -1,6 +1,7 @@
 <!--
 Copyright (c) 2016-present Arctic Ice Studio <development@arcticicestudio.com>
 Copyright (c) 2016-present Sven Greb <code@svengreb.de>
+Copyright (c) 2020 - Edited by ReplyDev <replydev@protonmail.com>
 
 Project:    Nord Notepad++
 Version:    0.1.0
@@ -37,8 +38,8 @@ References
     <WidgetStyle name="Tags attribute" styleID="26" fgColor="8FBCBB" bgColor="2E3440" fontStyle="0" />
     <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="88C0D0" bgColor="434C5E" fontStyle="0" />
     <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="2E3440" bgColor="2E3440" fontStyle="0" />
-    <WidgetStyle name="Active tab text" styleID="0" fgColor="2E3440" bgColor="D8DEE9" fontStyle="0" />
-    <WidgetStyle name="Inactive tabs" styleID="0" fgColor="2E3440" bgColor="D8DEE9" fontStyle="0" />
+    <WidgetStyle name="Active tab text" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
+    <WidgetStyle name="Inactive tabs" styleID="0" fgColor="D8DEE9" bgColor="2E3440" fontStyle="0" />
   </GlobalStyles>
   <LexerStyles>
     <LexerType name="bash" desc="bash" ext="sh bsh">


### PR DESCRIPTION
This commit fixes tab foreground and tab background to make text readable.

Broken:
![broken](https://user-images.githubusercontent.com/43727434/83504732-208f5b80-a4c5-11ea-8a29-4a14992f7503.png)
Fixed:
![fixed](https://user-images.githubusercontent.com/43727434/83504736-22f1b580-a4c5-11ea-8320-024e176f8712.png)

Sincerely.


